### PR TITLE
Add missing clone instructions

### DIFF
--- a/site/content/docs/tutorials/flyte/index.md
+++ b/site/content/docs/tutorials/flyte/index.md
@@ -35,6 +35,16 @@ This guide illustrates the deployment of Flyte on Google Kubernetes Engine (GKE)
 
 ![Architecture overview](architecture-overview.png)
 
+
+## Clone the repository
+
+Clone the repository with our guides and cd to the `flyte` directory by running these commands:
+```bash
+git clone https://github.com/ai-on-gke/tutorials-and-examples.git
+cd tutorials-and-examples/flyte
+```
+
+
 ## Setting up your GKE cluster with Terraform
 
 Let's start with setting up the infrastructure using Terraform. The Terraform configuration will create an [Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) or [Standard](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster) GKE cluster with GPU node pools (only for Standard clusters).

--- a/site/content/docs/tutorials/langchain-chatbot/index.md
+++ b/site/content/docs/tutorials/langchain-chatbot/index.md
@@ -77,6 +77,15 @@ This tutorial assumes you have the following:
 - Optional: Docker installed on your local machine (if you want to build and run the application locally)
 - Optional: Terraform installed on your local machine (if you want to use the automated deployment)
 
+
+## Clone the repository
+
+Clone the repository with our guides and cd to the `langchain-chatbot` directory by running these commands:
+```bash
+git clone https://github.com/ai-on-gke/tutorials-and-examples.git
+cd tutorials-and-examples/langchain-chatbot
+```
+
 ## Optional: Build and Run the Application Locally
 
 Running the application locally allows you to quickly preview the application and catch possible configuration issues, such as incorrect model base URI, before deploying the application to the cloud.


### PR DESCRIPTION
This PR add missing clone instructions to the Flyte and langchain-chatbot tutorials.