### PR TITLE
Add iap to agentic guides

### DIFF
--- a/site/content/docs/agentic/adk-llama-vllm/index.md
+++ b/site/content/docs/agentic/adk-llama-vllm/index.md
@@ -260,6 +260,11 @@ Run this command to submit our application to the repository:
 
 Now you can replace `<PROJECT_ID>` in the `deploy-agent.yaml` and run this command:
 
+
+ > [!NOTE]
+ > If you do not want to expose the app with IAP and just use `port-forward`,
+ you may want to change the type of the service from the `NodePort` to `ClusterIP`, since `port-forward` does not require an external port.
+
   ```bash
   kubectl apply -f deploy-agent.yaml
   ```
@@ -304,7 +309,7 @@ Go to the newly created directory:
    cd ../iap
    ```
 
-Navigate to the [Secure your app with Identity Aware Proxy guide](../../common/identity_aware_proxy) and follow the instructions to enable IAP.
+Navigate to the [Secure your app with Identity Aware Proxy guide](../../tutorials/security/identity-aware-proxy) and follow the instructions to enable IAP.
 
 
 

--- a/site/content/docs/agentic/adk-llama-vllm/index.md
+++ b/site/content/docs/agentic/adk-llama-vllm/index.md
@@ -273,15 +273,54 @@ You can review the status by running logs \-f command on the associated pod. The
   INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
   ```
 
+### Securely expose Agent's Web-UI with Identity Aware Proxy (IAP).
+
+Create a new directory for Terraform config:
+
+   ```bash
+   mkdir ../iap
+   ```
+
+Prepare the tfvars file that will be needed during the IAP guide. We also can specify some of the known variable values, so you only need to specify the remaining ones with the `<>` placeholder.
+
+   ```bash
+   cat <<EOF > ../iap/values.tfvars
+   project_id               = "$(terraform output -raw project_id)"
+   cluster_name             = "$(terraform output -raw gke_cluster_name)"
+   cluster_location         = "$(terraform output -raw gke_cluster_location)"
+   app_name                 = "adk-llama-vllm"
+   k8s_namespace            = "$(kubectl get svc adk-agent -o=jsonpath='{.metadata.namespace}')"
+   k8s_backend_service_name = "$(kubectl get svc adk-agent -o=jsonpath='{.metadata.name}')"
+   k8s_backend_service_port = "$(kubectl get svc adk-agent -o=jsonpath='{.spec.ports[0].port}')"
+   support_email            = "<SUPPORT_EMAIL>"
+   client_id                = "<CLIENT_ID>"
+   client_secret            = "<CLIENT_SECRET>"
+   EOF
+   ```
+
+Go to the newly created directory:
+
+   ```bash
+   cd ../iap
+   ```
+
+Navigate to the [Secure your app with Identity Aware Proxy guide](../../common/identity_aware_proxy) and follow the instructions to enable IAP.
+
+
+
+### [Alternative] Use Port-forward
+
+As an alternative, for a local testing, instead of IAP you can use the port-forward command:
+
+   ```bash
+   kubectl port-forward svc/adk-agent 8001:80
+   ```
+
+
 ### Testing
 
-To test your application, you can port-forward the agent service like this:
-
-  ```bash
-  kubectl port-forward svc/adk-agent 8001:80
-  ```
-
-And go to the [http://127.0.0.1:8001](http://127.0.0.1:8001). Try to ask about the weather in some city and check what will happen. It should look like this:
+Open web UI at the URL that is created during the IAP guide or [http://127.0.0.1:8001](http://127.0.0.1:8001) if you use port-forward.
+Try to ask about the weather in some city and check what will happen. It should look like this:
 ![](./image1.png)
 
 Note, that our tool has dummy data:

--- a/site/content/docs/agentic/adk-vertex/index.md
+++ b/site/content/docs/agentic/adk-vertex/index.md
@@ -331,7 +331,7 @@ It creates the following resources. For more information such as resource names 
     metadata:
       name: adk-agent
     spec:       
-      type: ClusterIP
+      type: NodePort
       ports:
         - port: 80
           targetPort: 8080
@@ -339,6 +339,10 @@ It creates the following resources. For more information such as resource names 
         app: adk-agent
     EOF
     ```
+
+    > [!NOTE]
+    > If you do not want to expose the app with IAP and just use `port-forward`,
+    you may want to change the type of the service from the `NodePort` to `ClusterIP`, since `port-forward` does not require an external port.	 
 
 7. Apply the manifest:
 
@@ -384,7 +388,7 @@ It creates the following resources. For more information such as resource names 
    cd ../iap
    ```
 
-4. Navigate to the [Secure your app with Identity Aware Proxy guide](../../common/identity_aware_proxy) and follow the instructions to enable IAP.
+4. Navigate to the [Secure your app with Identity Aware Proxy guide](../../tutorials/security/identity-aware-proxy) and follow the instructions to enable IAP.
 
 
 

--- a/site/content/docs/agentic/adk-vertex/index.md
+++ b/site/content/docs/agentic/adk-vertex/index.md
@@ -352,32 +352,71 @@ It creates the following resources. For more information such as resource names 
     kubectl rollout status deployment/adk-agent
     ```
 
+
+### Securely expose Agent's Web-UI with Identity Aware Proxy (IAP).
+
+1. Create a new directory for Terraform config:
+
+   ```bash
+   mkdir ../iap
+   ```
+
+2. Prepare the tfvars file that will be needed during the IAP guide. We also can specify some of the known variable values, so you only need to specify the remaining ones with the `<>` placeholder.
+
+   ```bash
+   cat <<EOF > ../iap/values.tfvars
+   project_id               = "$(terraform output -raw project_id)"
+   cluster_name             = "$(terraform output -raw gke_cluster_name)"
+   cluster_location         = "$(terraform output -raw gke_cluster_location)"
+   app_name                 = "adk-vertex"
+   k8s_namespace            = "$(kubectl get svc adk-agent -o=jsonpath='{.metadata.namespace}')"
+   k8s_backend_service_name = "$(kubectl get svc adk-agent -o=jsonpath='{.metadata.name}')"
+   k8s_backend_service_port = "$(kubectl get svc adk-agent -o=jsonpath='{.spec.ports[0].port}')"
+   support_email            = "<SUPPORT_EMAIL>"
+   client_id                = "<CLIENT_ID>"
+   client_secret            = "<CLIENT_SECRET>"
+   EOF
+   ```
+
+3. Go to the newly created directory:
+
+   ```bash
+   cd ../iap
+   ```
+
+4. Navigate to the [Secure your app with Identity Aware Proxy guide](../../common/identity_aware_proxy) and follow the instructions to enable IAP.
+
+
+
+### [Alternative] Use Port-forward
+
+As an alternative, for a local testing, instead of IAP you can use the port-forward command:
+
+   ```bash
+   kubectl port-forward svc/adk-agent 8080:80
+   ```
+
+
 ## Testing your Deployed Agent
 
-1. Forward port of the deployed application service:
+Open web UI at the URL that is created during the IAP guide or [http://127.0.0.1:8080](http://127.0.0.1:8080) if you use port-forward and test the web UI.
 
-    ```bash
-    kubectl port-forward svc/adk-agent 8080:80
-    ```
+The ADK dev UI allows you to interact with your agent, manage sessions, and view execution details directly in the browser.
+    
+To verify your agent is working as intended, you can:
+    
+   1. Select your agent from the dropdown menu.  
+   2. Type a message and verify that you receive an expected response from your agent.
+    
+   ![alt text](webui.png)
+    
+   As you can see from the screenshot, the agent works as expected and gives answers only for cities that are listed in the tool function.
+    
+   If you experience any unexpected behavior, check the pod logs for your agent using:
 
-2. Go to the [http://localhost:8080/](http://localhost:8080/) and test the web UI. You can test your agent by simply navigating to the kubernetes service URL in your web browser.
-
-    The ADK dev UI allows you to interact with your agent, manage sessions, and view execution details directly in the browser.
-    
-    To verify your agent is working as intended, you can:
-    
-    1. Select your agent from the dropdown menu.  
-    2. Type a message and verify that you receive an expected response from your agent.
-    
-    ![alt text](webui.png)
-    
-    As you can see from the screenshot, the agent works as expected and gives answers only for cities that are listed in the tool function.
-    
-    If you experience any unexpected behavior, check the pod logs for your agent using:
-
-    ```bash
-    kubectl logs -l app=adk-agent
-    ```
+   ```bash
+   kubectl logs -l app=adk-agent
+   ```
 
 ## Troubleshooting
 

--- a/site/content/docs/agentic/flowise/index.md
+++ b/site/content/docs/agentic/flowise/index.md
@@ -319,7 +319,7 @@ To learn more about the chart, please refer to its [page](https://artifacthub.io
    ```
 
 
-### Securely expose Flowise web-ui.
+### Securely expose Flowise Web-UI with Identity Aware Proxy.
 
 1. Create a new directory for Terraform config:
 
@@ -327,7 +327,7 @@ To learn more about the chart, please refer to its [page](https://artifacthub.io
     mkdir ../iap
     ```
 
-2. Prepare the tfvars file that will be needed during the IAP guide. We also can specify some of the known variable values, so you only need to specify the remaining ones with `<>` placeholders.
+2. Prepare the tfvars file that will be needed during the IAP guide. We also can specify some of the known variable values, so you only need to specify the remaining ones with the `<>` placeholder.
 
     ```bash
     cat <<EOF > ../iap/values.tfvars

--- a/site/content/docs/agentic/flowise/index.md
+++ b/site/content/docs/agentic/flowise/index.md
@@ -274,7 +274,7 @@ It creates the following resources. For more information such as resource names 
 
     > [!NOTE]
     > If you do not want to expose the app with IAP and just use `port-forward`,
-    you may want to change the type of the service from the `NodePort` to `ClusterIP`, since `port-forward` does not require an external port.	 
+    you may want to change the type of the service from the `NodePort` to `ClusterIP`, since `port-forward` does not require an external port.
 
 3. Install Flowise helm chart with the values from the file that was created previously.
 To learn more about the chart, please refer to its [page](https://artifacthub.io/packages/helm/cowboysysop/flowise). Especially for the [templates](https://artifacthub.io/packages/helm/cowboysysop/flowise?modal=template&template=deployment.yaml) and [default values](https://artifacthub.io/packages/helm/cowboysysop/flowise?modal=values).
@@ -350,7 +350,7 @@ To learn more about the chart, please refer to its [page](https://artifacthub.io
     cd ../iap
     ```
 
-4. Navigate to the [Secure your app with Identity Aware Proxy guide](../../common/identity_aware_proxy) and follow the instructions to enable IAP.
+4. Navigate to the [Secure your app with Identity Aware Proxy guide](../../tutorials/security/identity-aware-proxy) and follow the instructions to enable IAP.
 
 
 

--- a/site/content/docs/tutorials/security/_index.md
+++ b/site/content/docs/tutorials/security/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Security"
+linkTitle: "Security"
+weight: 30
+type: docs-root
+notoc: true
+tags:
+  - Tutorials
+  - Inference servers
+  - Security
+draft: false
+---

--- a/site/content/docs/tutorials/security/identity-aware-proxy/_index.md
+++ b/site/content/docs/tutorials/security/identity-aware-proxy/_index.md
@@ -1,0 +1,254 @@
+---
+linkTitle: "Identity Aware Proxy"
+title: "Securing Application with Identity Aware Proxy"
+description: "Overviews how to secure application endpoints with Identity Aware Proxy (IAP)"
+weight: 30
+type: docs
+owner:
+  - name: "Vlado Djerek"
+    link: https://github.com/volatilemolotov
+tags:
+    - Tutorials
+    - Inference Servers
+    - Security
+draft: false
+---
+This guide will show how to enable [Identity Aware Proxy (IAP)](https://cloud.google.com/iap/docs/concepts-overview) to securely expose your application to the internet.
+
+## Overview
+
+This guide will use our [Terraform module](https://github.com/ai-on-gke/common-infra/tree/main/common/modules/iap) in order to enable IAP for the application from one of our tutorials.
+
+## Enable IAP and create OAuth client
+
+1. Before securing the application with IAP, ensure that the OAuth consent screen is configured. Go to the [IAP page](https://console.cloud.google.com/security/iap) and click "Configure consent screen" if prompted.  
+2. Create an OAuth 2.0 client ID by visiting the [Credentials page](https://console.cloud.google.com/apis/credentials) and selecting "Create OAuth client ID". Use the `Web application` type and proceed with the creation. Save the Client ID and secret for later use.   
+3. Go back to the [Credentials page](https://console.cloud.google.com/apis/credentials), click on the OAuth 2.0 client ID you created, and add the redirect URI as follows: `https://iap.googleapis.com/v1/oauth/clientIds/<CLIENT_ID>:handleRedirect` (replace `<CLIENT_ID>` with the actual client ID). This is crucial because the redirect URI is used by the OAuth 2.0 authorization server to return the authorization code to your application. If it is not configured correctly, the authorization process will fail, and users will not be able to log in to the application.
+
+### Apply the IAP Terraform module 
+
+1. Create a directory for IAP terraform config. If you came here from another guide, then you should already have this directory created, otherwise, create it now:
+
+```shell
+mkdir iap
+cd iap
+```
+
+2. Create terraform files with the following contents:
+
+
+   File `iap.tf`:
+
+   ```
+   module "iap_auth" {
+     source = "github.com/ai-on-gke/common-infra//common/modules/iap-with-cluster?ref=refactor-iap"
+   
+     project_id =  var.project_id
+     cluster_name = var.cluster_name
+     cluster_location = var.cluster_location
+     namespace                = var.k8s_namespace
+     k8s_backend_service_name = var.k8s_backend_service_name
+     k8s_backend_service_port = var.k8s_backend_service_port
+     support_email            = var.support_email
+     app_name                 = var.app_name
+     client_id                = var.client_id
+     client_secret            = var.client_secret
+     domain                   = var.domain
+     members_allowlist        = var.members_allowlist
+     create_brand             = var.create_brand
+     k8s_ingress_name         = var.k8s_ingress_name
+     k8s_managed_cert_name    = var.k8s_managed_cert_name
+     k8s_iap_secret_name      = var.k8s_iap_secret_name
+     k8s_backend_config_name  = var.k8s_backend_config_name
+   }
+   ```
+
+   File `variables.tf`:
+
+   ```
+   variable "project_id" {
+     type        = string
+     description = "GCP project ID"
+   }
+   
+   variable "cluster_name" {
+     type = string
+     description = "Name of a target GKE cluster where the target application is deployed"
+   }
+   
+   variable "cluster_location" {
+     type = string
+     description = "Location of a target GKE cluster where the target application is deployed"
+   }
+   
+   
+   variable "app_name" {
+     type        = string
+     description = "App Name"
+   }
+   
+   # IAP settings
+   variable "create_brand" {
+     type        = bool
+     description = "Create Brand OAuth Screen"
+     default = false
+   }
+   
+   variable "k8s_namespace" {
+     type        = string
+     description = "Kubernetes namespace where resources are deployed"
+   }
+   variable "k8s_ingress_name" {
+     type        = string
+     description = "Name for k8s Ingress"
+     default = ""
+   }
+   
+   variable "k8s_managed_cert_name" {
+     type        = string
+     description = "Name for k8s managed certificate"
+     default = ""
+   }
+   
+   variable "k8s_iap_secret_name" {
+     type        = string
+     description = "Name for k8s iap secret"
+     default = ""
+   }
+   
+   variable "k8s_backend_config_name" {
+     type        = string
+     description = "Name of the Kubernetes Backend Config"
+     default = ""
+   }
+   
+   variable "k8s_backend_service_name" {
+     type        = string
+     description = "Name of the Backend Service"
+   }
+   
+   variable "k8s_backend_service_port" {
+     type        = number
+     description = "Name of the Backend Service Port"
+   }
+   
+   variable "domain" {
+     type        = string
+     description = "Provide domain for ingress resource and ssl certificate. "
+     default     = "{IP_ADDRESS}.sslip.io"
+   }
+   
+   variable "support_email" {
+     type        = string
+     description = "Email for users to contact with questions about their consent"
+     default     = ""
+   }
+   
+   variable "client_id" {
+     type        = string
+     description = "Client ID used for enabling IAP"
+     default     = ""
+   }
+   
+   variable "client_secret" {
+     type        = string
+     description = "Client secret used for enabling IAP"
+     default     = ""
+   }
+   
+   variable "members_allowlist" {
+     type    = list(string)
+     default = ["domain:your-domain.com"]
+   }
+   ```
+
+   File `outputs.tf`:
+
+   ```
+   output "app_public_ip" {
+     value = module.iap_auth.ip_address
+   }
+   
+   output "app_url" {
+     value = "https://${module.iap_auth.domain}"
+   }
+   
+   output "k8s_managed_cert_name" {
+     value = module.iap_auth.k8s_managed_cert_name
+   }
+   ```
+
+3. Create a tfvars file with the following values. 
+
+   > [!NOTE]
+   > If you came from another guide, then you may already have this file.
+
+   The file must have the following variables:
+
+   ```
+   project_id               = "<PROJECT_ID>"
+   cluster_name             = "<CLUSTER_NAME>"
+   cluster_location         = "<CLUSTER_LOCATION>"
+   app_name                 = "<APP_NAME>"
+   k8s_namespace            = "<KUBERNETES_NAMESPACE>"
+   k8s_backend_service_name = "<SERVICE_NAME>"
+   k8s_backend_service_port = "<SERVICE_PORT>"
+   support_email            = "<SUPPORT_EMAIL>"
+   client_id                = "<CLIENT_ID>"
+   client_secret            = "<CLIENT_SECRET>"
+   ```
+
+   Where:
+   
+      * `project_id` \-  The project ID.  
+      * `cluster_name` \- Name of a target cluster where app resources are deployed.  
+      * `cluster_location` \- Location of a target cluster.  
+      * `app_name` \- Name of the application. This will be used as a prefix for created resources names.  
+      * `k8s_namespace` \- The namespace where the app is deployed.  
+      * `k8s_backend_service_name` \- Name of a service to expose.  
+      * `k8s_backend_service_port` \-  Port of a service to expose.  
+      * `support_email` \- A support email to be shown in the authorization screen.  
+      * `client_id` \- ID of a created OAuth client.  
+      * `client_secret` \- Secret if a created OAuth client
+   
+   For information about other variables please refer to the `variables.tf` file. 
+
+4. Init the Terraform config:
+
+   ```
+   terraform init
+   ```
+
+5. Apply the IAP Terraform config:
+
+   ```shell
+   terraform apply -var-file values.tfvars
+   ```
+
+6. Wait for a managed certificate to be provisioned. Since the provisioning time for the certificate is longer than for other resources, it should be safe to assume that other resources are also ready:
+
+   ```shell
+   kubectl wait --for='jsonpath={.status.domainStatus[0].status}=Active' managedcertificate/$(terraform output -raw k8s_managed_cert_name) --timeout=20m
+   ```
+
+7. Get the url of the app:
+
+   ```
+   terraform output app_url
+   ```
+
+## Cleanup
+
+   ```
+   terraform destroy -var-file values.tfvars
+   ```
+
+## Troubleshooting
+
+### Can not create valid Healthcheck
+
+By default the Health check that is created for the GCP LoadBalancer backend is derived from the Pod readiness probe, so make sure that itvalues are compatible with GCP healthcheck.
+
+For example the service object has to use a port only from range 80 to 443.
+
+Read more [here](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#interpreted_hc).

--- a/site/content/docs/tutorials/security/identity-aware-proxy/_index.md
+++ b/site/content/docs/tutorials/security/identity-aware-proxy/_index.md
@@ -247,7 +247,7 @@ cd iap
 
 ### Can not create valid Healthcheck
 
-By default the Health check that is created for the GCP LoadBalancer backend is derived from the Pod readiness probe, so make sure that itvalues are compatible with GCP healthcheck.
+By default the Health check that is created for a GCP LoadBalancer backend is derived from the Pod readiness probe, so make sure that its values are compatible with GCP healthcheck.
 
 For example the service object has to use a port only from range 80 to 443.
 


### PR DESCRIPTION
This PR introduces tutorial on how to enable Identity Aware Proxy for applications from other guides. For now it was tested only for agentic guides. 

The PR for related changes in the codebase repo https://github.com/ai-on-gke/tutorials-and-examples/pull/58 