### PR TITLE
Add mention about custom role creation requirements in the adk/vertex…

### DIFF
--- a/site/content/docs/agentic/adk-vertex/index.md
+++ b/site/content/docs/agentic/adk-vertex/index.md
@@ -47,6 +47,9 @@ Ensure that you are signed in using the gcloud CLI tool. Run the following comma
 gcloud auth application-default login
 ```
 
+Make sure you have a permission to [create custom IAM roles](https://cloud.google.com/iam/docs/creating-custom-roles#required-roles).
+Your user must have `roles/iam.roleAdmin` or `roles/iam.organizationRoleAdmin` role.
+
 ## Infrastructure Setup
 
 ### Clone the repository


### PR DESCRIPTION
This PR add notion in the VertexAI guide that the user has to have a Role Administrator role in order to create another custom roles that is required by the changes that are introduced by this PR https://github.com/ai-on-gke/tutorials-and-examples/pull/59