### PR TITLE
Make IAP module source point to the main branch

### DIFF
--- a/site/content/docs/tutorials/security/identity-aware-proxy/_index.md
+++ b/site/content/docs/tutorials/security/identity-aware-proxy/_index.md
@@ -41,7 +41,7 @@ cd iap
 
    ```
    module "iap_auth" {
-     source = "github.com/ai-on-gke/common-infra//common/modules/iap-with-cluster?ref=refactor-iap"
+     source = "github.com/ai-on-gke/common-infra//common/modules/iap-with-cluster?ref=main"
    
      project_id =  var.project_id
      cluster_name = var.cluster_name


### PR DESCRIPTION

The PR https://github.com/ai-on-gke/common-infra/pull/5 has been merged, so we need to point to the main branch in our guide