### PR TITLE
Change adk/vertex readiness probe path

### DIFF
--- a/site/content/docs/agentic/adk-vertex/index.md
+++ b/site/content/docs/agentic/adk-vertex/index.md
@@ -321,7 +321,7 @@ It creates the following resources. For more information such as resource names 
                 value: "true"
             readinessProbe:
               httpGet:
-                path: /
+                path: /dev-ui/
                 port: 8080
               initialDelaySeconds: 10
               periodSeconds: 10


### PR DESCRIPTION
This PR changes the path of the readiness probe, which has to make it work properly with Identity Aware Proxy.