### PR TITLE
Fix lychee 404 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # Directories
 bin/
 deploy/
+node_modules/
 
 # IDEs
 .idea/
@@ -38,3 +39,4 @@ tfplan
 
 .hugo_build.lock
 go.sum
+.lycheecache

--- a/lychee.toml
+++ b/lychee.toml
@@ -21,4 +21,11 @@ cache_exclude_status = ["429","500..599","400..499"]
 cache = true
 no_progress = true
 verbose = "error"
-exclude = ["console.cloud.google.com/marketplace"]
+base = "site/public" 
+exclude = [
+  "console.cloud.google.com/marketplace",
+  "redis.io/about/about-stack",
+  "github.com/AI-Hypercomputer/inference-benchmark/issues/new",
+  "github.com/ai-on-gke/tutorials-and-examples/blob/main/nemo-rl-on-gke/llama3_1_8b_it",
+  "github.com/ai-on-gke/tutorials-and-examples/blob/main/nemo-rl-on-gke/qwen2_5_1_5b_it",
+]

--- a/lychee.toml
+++ b/lychee.toml
@@ -21,11 +21,12 @@ cache_exclude_status = ["429","500..599","400..499"]
 cache = true
 no_progress = true
 verbose = "error"
-base = "site/public" 
+root_dir = "site/public" 
 exclude = [
   "console.cloud.google.com/marketplace",
-  "redis.io/about/about-stack",
-  "github.com/AI-Hypercomputer/inference-benchmark/issues/new",
+  # GitHub issues/new requires authentication and cannot be link-checked
+  "github.com/.*/issues/new",
+  # Broken links in upstream nemo-rl-on-gke external README (subdirectory READMEs don't exist yet)
   "github.com/ai-on-gke/tutorials-and-examples/blob/main/nemo-rl-on-gke/llama3_1_8b_it",
   "github.com/ai-on-gke/tutorials-and-examples/blob/main/nemo-rl-on-gke/qwen2_5_1_5b_it",
-]
+ ]

--- a/lychee.toml
+++ b/lychee.toml
@@ -24,9 +24,7 @@ verbose = "error"
 root_dir = "site/public" 
 exclude = [
   "console.cloud.google.com/marketplace",
-  # GitHub issues/new requires authentication and cannot be link-checked
   "github.com/.*/issues/new",
-  # Broken links in upstream nemo-rl-on-gke external README (subdirectory READMEs don't exist yet)
   "github.com/ai-on-gke/tutorials-and-examples/blob/main/nemo-rl-on-gke/llama3_1_8b_it",
   "github.com/ai-on-gke/tutorials-and-examples/blob/main/nemo-rl-on-gke/qwen2_5_1_5b_it",
  ]

--- a/site/content/docs/agentic/agentic-llamaindex/index.md
+++ b/site/content/docs/agentic/agentic-llamaindex/index.md
@@ -110,7 +110,7 @@ File `app/rag_demo/__init__.py`:
 
 <details><summary>Expand to see key parts</summary>
 
-The application uses [Redis Stack](https://redis.io/about/about-stack/) as the vector store, with a defined schema for indexing movie data.
+The application uses [Redis Stack](https://redis.io/about/redis-stack/) as the vector store, with a defined schema for indexing movie data.
 
 ```python
 custom_schema = IndexSchema.from_dict(

--- a/site/content/docs/tutorials/frameworks-and-pipelines/llamaindex/index.md
+++ b/site/content/docs/tutorials/frameworks-and-pipelines/llamaindex/index.md
@@ -112,7 +112,7 @@ File `app/rag_demo/__init__.py`:
 <details><summary>Expand to see key parts</summary>
 
 
-In this demo we use [Redis-stack](https://redis.io/about/about-stack/) as our vector storage and we also have to define a data schema for it.
+In this demo we use [Redis-stack](https://redis.io/about/redis-stack/) as our vector storage and we also have to define a data schema for it.
 
 ```python
 custom_schema = IndexSchema.from_dict(

--- a/site/content/docs/tutorials/inference-servers/kserve/index.md
+++ b/site/content/docs/tutorials/inference-servers/kserve/index.md
@@ -60,7 +60,7 @@ Additionally, this tutorial includes an example of serving Gemma2 with vLLM in K
    ```
 
 ## Install KServe
-KServe relies on [Knative](https://knative.dev/docs/concepts/) and requires a networking layer. In this tutorial, we will use [Istio](https://istio.io/), the networking layer that integrates best with Knative.
+KServe relies on [Knative](https://knative.dev/docs/) and requires a networking layer. In this tutorial, we will use [Istio](https://istio.io/), the networking layer that integrates best with Knative.
 
 > [!NOTE]
 > You will see warnings that Autopilot mutated the CRDs during this tutorial. These warnings are safe to ignore.

--- a/site/layouts/partials/favicons.html
+++ b/site/layouts/partials/favicons.html
@@ -1,11 +1,11 @@
 
-<link rel="apple-touch-icon" href="{{ "favicons/apple-touch-icon-167x167.png" | relURL }}" sizes="167x167">
+<link rel="apple-touch-icon" href="{{ "favicons/apple-touch-icon-180x180.png" | relURL }}" sizes="180x180">
 <link rel="icon" type="image/png" href="{{ "favicons/favicon-16x16.png" | relURL }}" sizes="16x16">
 <link rel="icon" type="image/png" href="{{ "favicons/favicon-32x32.png" | relURL }}" sizes="32x32">
 <link rel="icon" type="image/png" href="{{ "favicons/android-48x48.png" | relURL }}" sizes="48x48">
-<link rel="icon" type="image/png" href="{{ "favicons/android-64x64.png" | relURL }}" sizes="64x64">
+<link rel="icon" type="image/png" href="{{ "favicons/favicon-64x64.png" | relURL }}" sizes="64x64">
 <link rel="icon" type="image/png" href="{{ "favicons/android-96x96.png" | relURL }}" sizes="96x96">
-<link rel="icon" type="image/png" href="{{ "favicons/android-128x128.png" | relURL }}" sizes="128x128">
+<link rel="icon" type="image/png" href="{{ "favicons/favicon-128x128.png" | relURL }}" sizes="128x128">
 <link rel="icon" type="image/png" href="{{ "favicons/favicon-96x96.png" | relURL }}" sizes="96x96" />
 <link rel="icon" type="image/svg+xml" href="{{ "favicons/favicon.svg" | relURL }}" />
 <link rel="shortcut icon" href="{{ "favicons/favicon.ico" | relURL }}" />

--- a/site/layouts/partials/page-meta-links.html
+++ b/site/layouts/partials/page-meta-links.html
@@ -42,7 +42,10 @@
 
   {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
   {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
-  {{ $issuesURL := printf "%s/issues/new?title=%s&template=documentation-issue-report.md" $gh_repo (safeURL $.Title ) -}}
+  {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title) -}}
+  {{ if not .Page.Params.externalSource.repository -}}
+    {{ $issuesURL = printf "%s&template=documentation-issue-report.md" $issuesURL -}}
+  {{ end -}}
   {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}
   {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
   {{ $newPageURL := printf "%s/new/%s?%s" $gh_repo (path.Dir $gh_repo_path) $newPageQS -}}


### PR DESCRIPTION
##  Fix lychee link-checking failures

### Resolves all 404 errors reported by lychee across two categories:

- Missing favicon files — favicons.html referenced three filenames that didn't exist (android-128x128.png, android-64x64.png, apple-touch-icon-167x167.png). 
- Updated to match the actual files present (favicon-128x128.png, favicon-64x64.png, apple-touch-icon-180x180.png).


### Broken external URLs — Fixed three stale links in source content:

- redis.io/about/about-stack/ → redis.io/about/redis-stack/ (page moved)
- knative.dev/docs/concepts/ → knative.dev/docs/ (page removed)
- inference-benchmark/issues/new?…&template=documentation-issue-report.md — template doesn't exist in that repo; fixed layout to omit the &template= param for external-source pages

### Lychee exclusions — Added patterns for URLs that cannot be reliably checked:
  
-   github.com/.*/issues/new (requires authentication)
-   Two upstream nemo-rl-on-gke subdirectory README links (broken in the external repo's content)