### PR TITLE
Harden GitHub Actions workflows per zizmor findings

### DIFF
--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -16,8 +16,12 @@
 # This workflow utilizes https://github.com/actions/github-script in GitHub Actions to apply labels to pull requests.
 #
 name: Label PR
-on: 
-  pull_request_target:
+# pull_request_target is required so the bot can label PRs from forks, but no
+# PR code is ever checked out and the untrusted PR body is only read as a
+# string for a regex match, never executed or interpolated into a shell
+# command.
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
   workflow_dispatch:
 jobs:
   label:
@@ -27,7 +31,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |-
             const keywords = [

--- a/.github/workflows/obsolete.yaml
+++ b/.github/workflows/obsolete.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Track Obsolete Issues
     steps:
       - name: Track stale issues and check if obsolete
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@a2983b8bed1923f44751c5c43237f479442827b3 # v3.37.4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -29,7 +29,7 @@ jobs:
     name: stale issues
     steps:
       - name: Stale issues
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -30,10 +30,11 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
          submodules: recursive
          fetch-depth: 0
+         persist-credentials: false
       - name: Build sourcefiles
         run: |
           HOST_UID=$(id -u)
@@ -45,7 +46,7 @@ jobs:
             -u ${HOST_UID}:${HOST_GID} \
             floryn90/hugo:0.145.0-ext-alpine build -e production
       - id: "auth"
-        uses: "google-github-actions/auth@v2"
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           project_id: ${{ secrets.GCP_PROJECT }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -63,7 +64,7 @@ jobs:
         id: deploy
         env:
           ACTIONS_STEP_DEBUG: true
-        uses: google-github-actions/deploy-appengine@v2
+        uses: google-github-actions/deploy-appengine@a343979004148afb93c94c712b467e8e9f01b06b # v2.1.8
         with:
           deliverables: site/app.yaml
           project_id: ${{ secrets.GCP_PROJECT }}
@@ -87,4 +88,6 @@ jobs:
             echo "No versions to delete; 20 or fewer versions exist."
           fi
       - name: Test
-        run: curl "${{ steps.deploy.outputs.url }}"
+        run: curl "${STEPS_DEPLOY_OUTPUTS_URL}"
+        env:
+          STEPS_DEPLOY_OUTPUTS_URL: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
## Summary

A [zizmor](https://docs.zizmor.sh/) security scan of this repository's GitHub Actions workflows flagged the following:

- **`unpinned-uses` (high, ×7)** — `actions/stale@v8`, `actions/github-script@v6`, `actions/checkout@v4`, `google-github-actions/auth@v2`, `google-github-actions/deploy-appengine@v2`, and `github/codeql-action/upload-sarif@v3` were referenced by mutable version tag rather than a pinned commit SHA, which allows the upstream action's code to change without a corresponding change in this repo.
- **`artipacked` (medium)** — the checkout step in `website.yaml` did not set `persist-credentials: false`, leaving the `GITHUB_TOKEN` credential on disk and available to any subsequent step in the job.
- **`template-injection` (informational)** — `website.yaml`'s final `Test` step interpolated `${{ steps.deploy.outputs.url }}` directly into a `curl` shell command, which could expand into attacker-controllable code if that output were ever influenced by untrusted input.
- **`dangerous-triggers` (high, confidence: medium)** — `label-pr.yaml` uses the `pull_request_target` trigger, which the audit flags because it's frequently combined with a checkout of untrusted PR code and thus commonly exploited.

## Changes

- Pinned all 7 flagged actions to their resolved commit SHAs (with the human-readable version kept as a trailing comment).
- Added `persist-credentials: false` to the `website.yaml` checkout step. This job only builds/deploys and never needs the checked-out credentials to push.
- Fixed the template-injection risk by passing the deploy URL through an environment variable (`STEPS_DEPLOY_OUTPUTS_URL`) instead of interpolating it directly into the shell command.
- Reviewed and suppressed the `dangerous-triggers` finding on `label-pr.yaml` with an inline `zizmor: ignore` comment explaining the reasoning: the job never checks out PR code, and the untrusted PR body is only read as a plain string for a regex match — it's never executed or interpolated into a shell command — so the exploit pattern the audit assumes doesn't apply here. `pull_request_target` is required so the bot can label PRs opened from forks.

## Test plan

- [x] `zizmor` reports no findings against these workflows after the change (`No findings to report. Good job!`)
- [x] YAML validated as syntactically correct
- [ ] Confirm CI run on this PR passes with the pinned action versions
- [ ] Manually verify the App Engine deploy workflow still succeeds end-to-end
- [ ] Manually verify `label-pr.yaml` still labels a test PR correctly