### PR TITLE
Accept HTTP 202 in lychee link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -15,7 +15,7 @@
 max_concurrency = 2
 user_agent = "curl/7.83. 1"
 retry_wait_time = 10
-accept = ["200", "429"]
+accept = ["200", "202", "429"]
 exclude_all_private = true
 cache_exclude_status = ["429","500..599","400..499"]
 cache = true


### PR DESCRIPTION
## Summary

The `link-test` Cloud Build check has been failing on unrelated PRs (e.g. #222) because `https://build.nvidia.com/...` links on the NIM-on-GKE blueprint pages now return `202 Accepted` instead of `200 OK`. `lychee.toml`'s `accept` list only allowed `200` and `429`, so `lychee` flagged every page linking to `build.nvidia.com` as broken:

```
[site/public/docs/blueprints/nims-on-gke/nim-llm/index.html]:
[202] https://build.nvidia.com/explore/discover?signin=true (at 754:173) | Rejected status code: 202 Accepted
```

Affected pages: `nims-on-gke/index.html`, `nims-on-gke/nim-llm/index.html`, `nims-on-gke/nim-virtual-screening/index.html`, and the `tags/blueprints`, `tags/drug-discovery`, `tags/nim-on-gke`, `tags/nvidia` tag pages.

## Change

Add `"202"` to `lychee.toml`'s `accept` list, alongside the existing `200`/`429` exceptions.

Note: the link-check result cache (`gs://ai-on-gke-website-htmltest-cache/.lycheecache`) stores the raw HTTP status code, not a precomputed pass/fail verdict — acceptance is re-evaluated against the current `accept` list on each run, so this fix takes effect immediately without needing to clear the existing cache.

## Test plan

- [ ] Confirm the `link-test` Cloud Build check passes on this PR